### PR TITLE
Hotfix submenu

### DIFF
--- a/includes/class-static_press_admin.php
+++ b/includes/class-static_press_admin.php
@@ -103,8 +103,7 @@ class static_press_admin {
 			__($this->plugin_name.' Options', self::TEXT_DOMAIN) ,
 			self::ACCESS_LEVEL,
 			self::OPTION_PAGE . '-options' ,
-			array($this, 'options_page'),
-			plugins_url('images/staticpress_options.png', dirname(__FILE__))
+			array($this, 'options_page')
 			);
 
 		do_action('StaticPress::admin_menu', self::OPTION_PAGE);

--- a/tests/includes/test-class-static_press.php
+++ b/tests/includes/test-class-static_press.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Class StaticPressTest
+ *
+ * @package StaticPress
+ */
+
+/**
+ * StaticPress test case.
+ */
+/** @noinspection PhpUndefinedClassInspection */
+class StaticPressTest extends WP_UnitTestCase {
+
+    /**
+     * url_table() should return prefix for WordPress tables + 'urls'.
+     */
+    public function test_url_table() {
+        $this->assertEquals( 'wptests_urls', static_press::url_table() );
+    }
+}

--- a/tests/includes/test-class-static_press_admin.php
+++ b/tests/includes/test-class-static_press_admin.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class StaticPressAdminTest
+ *
+ * @package StaticPress
+ */
+
+/**
+ * StaticPress test case.
+ */
+/** @noinspection PhpUndefinedClassInspection */
+class StaticPressAdminTest extends WP_UnitTestCase {
+    // @see https://wordpress.stackexchange.com/a/207363
+    public function setUp() {
+        parent::setUp();
+        $user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+        wp_set_current_user( $user_id );
+    }
+
+    public function tearDown() {
+        parent::tearDown();
+    }
+
+    /**
+     * admin_menu() should not throw any exception.
+     */
+    public function test_admin_menu() {
+        $staticPressAdmin = new static_press_admin(plugin_basename(__FILE__));
+        $staticPressAdmin->admin_menu();
+    }
+}


### PR DESCRIPTION
Fix bug that can't display admin page

- Fix bug that can't display admin page because calling
  add_submenu_page() function is not correct, however luckily it seems
  to have been worked until WordPress 5.2.