### PR TITLE
Fix bug that link tag on feed is not replaced

### DIFF
--- a/includes/content_filters/class-static-press-content-filter.php
+++ b/includes/content_filters/class-static-press-content-filter.php
@@ -62,7 +62,7 @@ class Static_Press_Content_Filter {
 	}
 
 	/**
-	 * Adds meta tag for last modified.
+	 * Adds <meta> tag for set last modified into top of HTML <head> tag.
 	 * 
 	 * @param string $content   Content.
 	 * @param int    $http_code HTTP responce code.
@@ -87,6 +87,7 @@ class Static_Press_Content_Filter {
 
 	/**
 	 * Rewrites generator tag.
+	 * This function seems to intend to add this plugin name and version into generator tag.
 	 * 
 	 * @param string $content   Content.
 	 * @param int    $http_code HTTP status code.

--- a/tests/testresources/replace_relative_uri-after.html
+++ b/tests/testresources/replace_relative_uri-after.html
@@ -33,5 +33,10 @@ Hello world!
 <img src="/sub/test.png">
 <form action="/sub/action">
 </form>
+<!--Function replace_relative_uri() should replace absolute URL of static site home to relative URL.-->
+<!--@see http://webfood.info/staticpress-s3/#feedindexhtmlurl-->
+<!--This link tag seems to work as hyperlink to the channel when subscribe feed.-->
+<!--@see @see https://www.w3schools.com/xml/xml_rss.asp-->
+<link>https://static-site.com/sub</link>
 </body>
 </html>

--- a/tests/testresources/replace_relative_uri-before.html
+++ b/tests/testresources/replace_relative_uri-before.html
@@ -33,5 +33,10 @@ Hello world!
 <img src="https://static-site.com/sub/test.png">
 <form action="https://static-site.com/sub/action">
 </form>
+<!--Function replace_relative_uri() should replace absolute URL of static site home to relative URL.-->
+<!--@see http://webfood.info/staticpress-s3/#feedindexhtmlurl-->
+<!--This link tag seems to work as hyperlink to the channel when subscribe feed.-->
+<!--@see @see https://www.w3schools.com/xml/xml_rss.asp-->
+<link>https://dynamic-site.com/sub</link>
 </body>
 </html>


### PR DESCRIPTION
Fix bug that link tag on feed is not replaced by static site URL.
This link tag seems to work as hyperlink to the channel when
subscribe feed.
@see http://webfood.info/staticpress-s3/#feedindexhtmlurl
@see https://www.w3schools.com/xml/xml_rss.asp