### PR TITLE
Replace require with require_once

### DIFF
--- a/includes/class-static-press-static-file-judger.php
+++ b/includes/class-static-press-static-file-judger.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes;
 
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
 use static_press\includes\infrastructure\Static_Press_Document_Root_Getter;
 /**
  * Model URL.

--- a/includes/class-static-press-url-collector.php
+++ b/includes/class-static-press-url-collector.php
@@ -7,51 +7,21 @@
 
 namespace static_press\includes;
 
-if ( ! class_exists( 'static_press\includes\content_filters\Static_Press_Content_Filter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter.php';
-}
-if ( ! class_exists( 'static_press\includes\factories\Static_Press_Factory_Model_Url_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\factories\Static_Press_Factory_Model_Url_Term' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-term.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_File_Scanner' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-scanner.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Author' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-author.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Front_Page' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-front-page.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Seo' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-seo.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Single' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-single.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Term' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-term.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-term.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-scanner.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-author.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-front-page.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-seo.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-single.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-term.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\content_filters\Static_Press_Content_Filter;
 use static_press\includes\factories\Static_Press_Factory_Model_Url_Static_File;
 use static_press\includes\factories\Static_Press_Factory_Model_Url_Term;

--- a/includes/class-static-press-url-filter.php
+++ b/includes/class-static-press-url-filter.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\models\Static_Press_Model_Static_File;
 use static_press\includes\Static_Press_Site_Dependency;
 /**

--- a/includes/class-static-press-url-updater.php
+++ b/includes/class-static-press-url-updater.php
@@ -7,21 +7,13 @@
 
 namespace static_press\includes;
 
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Static_FIle_Judger' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-static-file-judger.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-static-file-judger.php';
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\infrastructure\Static_Press_Document_Root_Getter;
-use static_press\includes\Static_Press_Model_Url;
+use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\Static_Press_Static_FIle_Judger;
 /**
  * URL Updater.

--- a/includes/class-static-press.php
+++ b/includes/class-static-press.php
@@ -7,45 +7,19 @@
 
 namespace static_press\includes;
 
-if ( ! class_exists( 'static_press\includes\content_filters\Static_Press_Content_Filter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter.php';
-}
-if ( ! class_exists( 'static_press\includes\content_filters\Static_Press_Content_Filter_Replace_Relative_Uri' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter-replace-relative-uri.php';
-}
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Fetch' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-fetch.php';
-}
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Finalyze' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-finalyze.php';
-}
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Init' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-init.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_File_System_Operator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-system-operator.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Date_Time_Factory' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Remote_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-remote-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Terminator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-terminator.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Url_Filter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-filter.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/content_filters/class-static-press-content-filter-replace-relative-uri.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-fetch.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-finalyze.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-init.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-system-operator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-remote-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-terminator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-filter.php';
 use static_press\includes\content_filters\Static_Press_Content_Filter;
 use static_press\includes\content_filters\Static_Press_Content_Filter_Replace_Relative_Uri;
 use static_press\includes\controllers\Static_Press_Ajax_Fetch;
@@ -56,9 +30,9 @@ use static_press\includes\infrastructure\Static_Press_File_System_Operator;
 use static_press\includes\repositories\Static_Press_Repository;
 use static_press\includes\Static_Press_Date_Time_Factory;
 use static_press\includes\Static_Press_Remote_Getter;
-use static_press\includes\Static_Press_Url_Filter;
 use static_press\includes\Static_Press_Site_Dependency;
 use static_press\includes\Static_Press_Terminator;
+use static_press\includes\Static_Press_Url_Filter;
 /**
  * StaticPress.
  */

--- a/includes/content_filters/class-static-press-content-filter-replace-relative-uri.php
+++ b/includes/content_filters/class-static-press-content-filter-replace-relative-uri.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\content_filters;
 
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\Static_Press_Site_Dependency;
 /**
  * Content filter.

--- a/includes/content_filters/class-static-press-content-filter.php
+++ b/includes/content_filters/class-static-press-content-filter.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\content_filters;
 
-if ( ! class_exists( 'static_press\includes\Static_Press_Plugin_Information' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-plugin-information.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-plugin-information.php';
 use static_press\includes\Static_Press_Plugin_Information;
 /**
  * Content filter.

--- a/includes/controllers/class-static-press-ajax-fetch.php
+++ b/includes/controllers/class-static-press-ajax-fetch.php
@@ -7,24 +7,12 @@
 
 namespace static_press\includes\controllers;
 
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Processor' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-processor.php';
-}
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Fetched' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-fetched.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository_Progress' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_404' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Fetch_Result' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-fetch-result.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-processor.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-fetched.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-fetch-result.php';
 use static_press\includes\controllers\Static_Press_Ajax_Processor;
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\models\Static_Press_Model_Url_Fetched;

--- a/includes/controllers/class-static-press-ajax-finalyze.php
+++ b/includes/controllers/class-static-press-ajax-finalyze.php
@@ -7,25 +7,12 @@
 
 namespace static_press\includes\controllers;
 
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Processor' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax_processor.php';
-}
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_200' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_404_Dump' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404-dump.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository_Progress' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
-}
-
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-processor.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404-dump.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\controllers\Static_Press_Ajax_Processor;
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\repositories\Static_Press_Repository_Progress;

--- a/includes/controllers/class-static-press-ajax-init.php
+++ b/includes/controllers/class-static-press-ajax-init.php
@@ -7,13 +7,8 @@
 
 namespace static_press\includes\controllers;
 
-if ( ! class_exists( 'static_press\includes\controllers\Static_Press_Ajax_Processor' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax_processor.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Url_Updater' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
-}
-
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/controllers/class-static-press-ajax-processor.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
 use static_press\includes\controllers\Static_Press_Ajax_Processor;
 use static_press\includes\Static_Press_Url_Updater;
 

--- a/includes/controllers/class-static-press-ajax-processor.php
+++ b/includes/controllers/class-static-press-ajax-processor.php
@@ -7,33 +7,15 @@
 
 namespace static_press\includes\controllers;
 
-if ( ! class_exists( 'static_press\includes\factories\Static_Press_Factory_Static_File_Creator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-static-file-creator.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository_Progress' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_200_Crawl' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200-crawl.php';
-}
-if ( ! class_exists( 'static_press\includes\static_file_creators\Static_Press_Static_File_Creator_Remote' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-remote.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Date_Time_Factory' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Terminator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-terminator.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Url_Collector' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-collector.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-static-file-creator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository-progress.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200-crawl.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-remote.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-terminator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-collector.php';
 use static_press\includes\factories\Static_Press_Factory_Static_File_Creator;
 use static_press\includes\infrastructure\Static_Press_Document_Root_Getter;
 use static_press\includes\models\Static_Press_Model_Url;

--- a/includes/factories/class-static-press-factory-model-url-static-file.php
+++ b/includes/factories/class-static-press-factory-model-url-static-file.php
@@ -7,15 +7,9 @@
 
 namespace static_press\includes\factories;
 
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\infrastructure\Static_Press_Document_Root_Getter;
 use static_press\includes\models\Static_Press_Model_Url_Static_File;
 use static_press\includes\Static_Press_Site_Dependency;

--- a/includes/factories/class-static-press-factory-model-url-term.php
+++ b/includes/factories/class-static-press-factory-model-url-term.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\factories;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Term' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-term.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-term.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url_Term;
 use static_press\includes\repositories\Static_Press_Repository;
 

--- a/includes/factories/class-static-press-factory-static-file-creator.php
+++ b/includes/factories/class-static-press-factory-static-file-creator.php
@@ -7,18 +7,11 @@
 
 namespace static_press\includes\factories;
 
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_200_Crawl' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200-crawl.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_404_Dump' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404-dump.php';
-}
-if ( ! class_exists( 'static_press\includes\static_file_creators\Static_Press_Static_File_Creator_Local' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-local.php';
-}
-if ( ! class_exists( 'static_press\includes\static_file_creators\Static_Press_Static_File_Creator_Remote' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-remote.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200-crawl.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404-dump.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-local.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator-remote.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\response_processors\Static_Press_Response_Processor_200_Crawl;
 use static_press\includes\response_processors\Static_Press_Response_Processor_404_Dump;

--- a/includes/infrastructure/class-static-press-file-scanner.php
+++ b/includes/infrastructure/class-static-press-file-scanner.php
@@ -7,15 +7,9 @@
 
 namespace static_press\includes\infrastructure;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\factories\Static_Press_Factory_Model_Url_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-static-file.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/factories/class-static-press-factory-model-url-static-file.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\models\Static_Press_Model_Url_Static_File;
 use static_press\includes\factories\Static_Press_Factory_Model_Url_Static_File;

--- a/includes/models/class-static-press-model-static-file.php
+++ b/includes/models/class-static-press-model-static-file.php
@@ -7,15 +7,9 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Failed' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-failed.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Succeed' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-succeed.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-failed.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-succeed.php';
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\models\Static_Press_Model_Url_Failed;
 use static_press\includes\models\Static_Press_Model_Url_Succeed;

--- a/includes/models/class-static-press-model-url-author.php
+++ b/includes/models/class-static-press-model-url-author.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\repositories\Static_Press_Repository;
 /**
  * Model URL author.

--- a/includes/models/class-static-press-model-url-failed.php
+++ b/includes/models/class-static-press-model-url-failed.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url-fetched.php
+++ b/includes/models/class-static-press-model-url-fetched.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\models\Static_Press_Model_Url;
 /**

--- a/includes/models/class-static-press-model-url-front-page.php
+++ b/includes/models/class-static-press-model-url-front-page.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
 use static_press\includes\repositories\Static_Press_Repository;
 use static_press\includes\Static_Press_Site_Dependency;
 /**

--- a/includes/models/class-static-press-model-url-other.php
+++ b/includes/models/class-static-press-model-url-other.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url-seo.php
+++ b/includes/models/class-static-press-model-url-seo.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url-single.php
+++ b/includes/models/class-static-press-model-url-single.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url-static-file.php
+++ b/includes/models/class-static-press-model-url-static-file.php
@@ -7,15 +7,9 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 use static_press\includes\Static_Press_Site_Dependency;

--- a/includes/models/class-static-press-model-url-succeed.php
+++ b/includes/models/class-static-press-model-url-succeed.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url-term.php
+++ b/includes/models/class-static-press-model-url-term.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\models\Static_Press_Model_Url;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/models/class-static-press-model-url.php
+++ b/includes/models/class-static-press-model-url.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\models;
 
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\repositories\Static_Press_Repository;
 /**

--- a/includes/repositories/class-static-press-repository-progress.php
+++ b/includes/repositories/class-static-press-repository-progress.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\repositories;
 
-if ( ! class_exists( 'static_press\includes\Static_Press_Adapter_Transient' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-adapter-transient.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Date_Time_Factory' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-date-time-factory.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-adapter-transient.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
 use static_press\includes\Static_Press_Adapter_Transient;
 use static_press\includes\Static_Press_Date_Time_Factory;
 

--- a/includes/repositories/class-static-press-repository.php
+++ b/includes/repositories/class-static-press-repository.php
@@ -7,12 +7,8 @@
 
 namespace static_press\includes\repositories;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Fetched' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-fetched.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Date_Time_Factory' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-fetched.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
 use static_press\includes\models\Static_Press_Model_Url_Fetched;
 use static_press\includes\Static_Press_Date_Time_Factory;
 

--- a/includes/response_processors/class-static-press-response-processor-200-crawl.php
+++ b/includes/response_processors/class-static-press-response-processor-200-crawl.php
@@ -7,18 +7,10 @@
 
 namespace static_press\includes\response_processors;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Url_Other' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-other.php';
-}
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_200' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Site_Dependency' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Url_Updater' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-url-other.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-200.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-site-dependency.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
 use static_press\includes\models\Static_Press_Model_Url_Other;
 use static_press\includes\response_processors\Static_Press_Response_Processor_200;
 use static_press\includes\Static_Press_Site_Dependency;

--- a/includes/response_processors/class-static-press-response-processor-200.php
+++ b/includes/response_processors/class-static-press-response-processor-200.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\response_processors;
 
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor.php';
 use static_press\includes\response_processors\Static_Press_Response_Processor;
 
 /**

--- a/includes/response_processors/class-static-press-response-processor-404-dump.php
+++ b/includes/response_processors/class-static-press-response-processor-404-dump.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\response_processors;
 
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor_404' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor-404.php';
 use static_press\includes\response_processors\Static_Press_Response_Processor_404;
 
 /**

--- a/includes/response_processors/class-static-press-response-processor-404.php
+++ b/includes/response_processors/class-static-press-response-processor-404.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\response_processors;
 
-if ( ! class_exists( 'static_press\includes\response_processors\Static_Press_Response_Processor' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/response_processors/class-static-press-response-processor.php';
 use static_press\includes\response_processors\Static_Press_Response_Processor;
 
 /**

--- a/includes/response_processors/class-static-press-response-processor.php
+++ b/includes/response_processors/class-static-press-response-processor.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\response_processors;
 
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_File_System_Operator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-system-operator.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-system-operator.php';
 use static_press\includes\infrastructure\Static_Press_File_System_Operator;
 
 /**

--- a/includes/static_file_creators/class-static-press-static-file-creator-local.php
+++ b/includes/static_file_creators/class-static-press-static-file-creator-local.php
@@ -7,18 +7,10 @@
 
 namespace static_press\includes\static_file_creators;
 
-if ( ! class_exists( 'static_press\includes\exceptions\Static_Press_Business_Logic_Exception' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_Document_Root_Getter' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
-}
-if ( ! class_exists( 'static_press\includes\infrastructure\Static_Press_File_System_Operator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-file-system-operator.php';
-}
-if ( ! class_exists( 'static_press\includes\static_file_creators\Static_Press_Static_File_Creator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/exceptions/class-static-press-business-logic-exception.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-document-root-getter.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/infrastructure/class-static-press-file-system-operator.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator.php';
 use static_press\includes\exceptions\Static_Press_Business_Logic_Exception;
 use static_press\includes\infrastructure\Static_Press_Document_Root_Getter;
 use static_press\includes\infrastructure\Static_Press_File_System_Operator;

--- a/includes/static_file_creators/class-static-press-static-file-creator-remote.php
+++ b/includes/static_file_creators/class-static-press-static-file-creator-remote.php
@@ -7,9 +7,7 @@
 
 namespace static_press\includes\static_file_creators;
 
-if ( ! class_exists( 'static_press\includes\static_file_creators\Static_Press_Static_File_Creator' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/static_file_creators/class-static-press-static-file-creator.php';
 use static_press\includes\static_file_creators\Static_Press_Static_File_Creator;
 /**
  * Class Static_Press_Static_File_Creator_Remote

--- a/includes/static_file_creators/class-static-press-static-file-creator.php
+++ b/includes/static_file_creators/class-static-press-static-file-creator.php
@@ -7,15 +7,9 @@
 
 namespace static_press\includes\static_file_creators;
 
-if ( ! class_exists( 'static_press\includes\models\Static_Press_Model_Static_File' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Date_Time_Factory' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press_Url_Updater' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/models/class-static-press-model-static-file.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-date-time-factory.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-url-updater.php';
 use static_press\includes\models\Static_Press_Model_Static_File;
 use static_press\includes\Static_Press_Date_Time_Factory;
 use static_press\includes\Static_Press_Url_Updater;

--- a/plugin.php
+++ b/plugin.php
@@ -46,12 +46,8 @@ if ( ! defined( 'STATIC_PRESS_PLUGIN_DIR' ) ) {
 	 */
 	define( 'STATIC_PRESS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 }
-if ( ! class_exists( 'Static_Press_Admin' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-admin.php';
-}
-if ( ! class_exists( 'static_press\includes\Static_Press' ) ) {
-	require STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-admin.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press.php';
 use static_press\includes\Static_Press;
 
 load_plugin_textdomain( Static_Press_Admin::TEXT_DOMAIN, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,12 +10,16 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die;
 }
 
-if ( ! class_exists( 'Static_Press_Admin' ) ) {
-	require dirname( __FILE__ ) . '/includes/class-static-press-admin.php';
+if ( ! defined( 'STATIC_PRESS_PLUGIN_DIR' ) ) {
+	/**
+	 * Plugin Directory.
+	 *
+	 * @var string $STATIC_PRESS_PLUGIN_DIR Plugin folder directory path. Eg. `/var/www/html/web/app/plugins/staticpress2019/`
+	 */
+	define( 'STATIC_PRESS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 }
-if ( ! class_exists( 'static_press\includes\repositories\Static_Press_Repository' ) ) {
-	require dirname( __FILE__ ) . '/includes/repositories/class-static-press-repository.php';
-}
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/class-static-press-admin.php';
+require_once STATIC_PRESS_PLUGIN_DIR . 'includes/repositories/class-static-press-repository.php';
 use static_press\includes\repositories\Static_Press_Repository;
 
 delete_option( Static_Press_Admin::OPTION_STATIC_URL );


### PR DESCRIPTION
#7 Replace require with require_once.
The best practice in WordPress seems to use require_once.
@see [Best Practices | Plugin Developer Handbook | WordPress Developer Resources](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#conditional-loading)